### PR TITLE
Updated typos, duplicate FAQ and formatted address in Contact.jsx

### DIFF
--- a/client/src/pages/Contact.jsx
+++ b/client/src/pages/Contact.jsx
@@ -29,15 +29,13 @@ export const Contact = () => {
                     <div class=' '>
     <p class='text-2xl text-yellow-500'>Contact Information</p>
 
-    <div class='mt-4'>
-        <p class='text-xl pb-1'>Address:</p>
-        <ul class='list-disc pl-4 text-lg'>
-            <li>JobLane</li>
-            <li>Wall Street</li>
-            <li>New York, 123</li>
-            <li>United States</li>
-        </ul>
-    </div>
+   <div class='mt-4'>
+    <p class='text-xl pb-1'>Address:</p>
+    <p class='text-lg'>
+        JobLane, Wall Street, New York, 123, United States
+    </p>
+</div>
+
 
     <div class='mt-4'>
         <p class='text-xl pb-1'>Email:</p>
@@ -85,7 +83,7 @@ export const Contact = () => {
                             </h2>
                             <div id="accordion-collapse-body-1" className={`${que1? "flex":"hidden"}`}  aria-labelledby="accordion-collapse-heading-1">
                                 <div className="p-5 border border-b-0 border-gray-200 dark:border-gray-700 dark:bg-gray-950">
-                                    <p className="mb-2 text-gray-500 dark:text-gray-400">Ans: To crate an account, click on the "Register" button located at the top right corner of the homepage. Fill in your personal information, including your name, email address, and a secure password. Once your account is created, you can start exploring jobs.</p>
+                                    <p className="mb-2 text-gray-500 dark:text-gray-400">Ans: To create an account, click on the "Register" button located at the top right corner of the homepage. Fill in your personal information, including your name, email address, and a secure password. Once your account is created, you can start exploring jobs.</p>
                                 </div>
                             </div>
                             <h2 id="accordion-collapse-heading-2">
@@ -103,7 +101,7 @@ export const Contact = () => {
                             </div>
                             <h2 id="accordion-collapse-heading-3">
                                 <button onClick={()=>setQue3(!que3)} type="button" className="flex items-center justify-between w-full p-5 font-medium text-left text-gray-500 border dark:focus:ring-gray-800 dark:border-gray-700 dark:text-gray-400  dark:hover:bg-gray-900" data-accordion-target="#accordion-collapse-body-3" aria-expanded="false" aria-controls="accordion-collapse-body-3">
-                                    <span >How do I create an account on your job application platform?</span>
+                                    <span >How can I check the status of my job application?</span>
                                     <svg data-accordion-icon className="w-3 h-3 rotate-180 shrink-0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
                                         <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5 5 1 1 5" />
                                     </svg>


### PR DESCRIPTION
This pull request addresses three issues on the "Contact" tab of our website:

**Address Formatting:** The address has been reformatted to appear as a single block of text for improved presentation.

**Typo Correction:** A typo in the FAQ section regarding account creation ("crate" corrected to "create") has been fixed.

**Question Replacement:** I've replaced the duplicate question about account creation with a more suitable question, "How can I check the status of my job application?", aligning it with the provided answer.

Please review and merge the pull request. Thank you.